### PR TITLE
Example of how to write and import typescript.

### DIFF
--- a/source/hotkey.ts
+++ b/source/hotkey.ts
@@ -1,0 +1,5 @@
+export var lastClip = "Error";
+
+export function clip(text: string): void {
+  lastClip = text;
+}

--- a/source/intel.js
+++ b/source/intel.js
@@ -1,3 +1,5 @@
+import { clip, lastClip } from "./hotkey";
+
 /* global define, Crux, NeptunesPride, Mousetrap, jQuery, Cookies, $ */
 
 const sat_version = "2.21";
@@ -483,11 +485,6 @@ function NeptunesPrideAgent() {
   let title = document?.currentScript?.title || `SAT ${sat_version}`;
   let version = title.replace(/^.*v/, "v");
   console.log(title);
-
-  var lastClip = "Error";
-  let clip = function (text) {
-    lastClip = text;
-  };
 
   let copy = function (reportFn) {
     return function () {


### PR DESCRIPTION
For typescript files, no extension should be provided to the import. This will cause typescript compilation on the ts file and import the resulting javascript symbols.