### PR TITLE
Add new hotkey for csv generation.

### DIFF
--- a/source/intel.js
+++ b/source/intel.js
@@ -1005,6 +1005,32 @@ function NeptunesPrideAgent() {
     "<p>This same report can also be viewed via the menu; enter the agent and choose it from the dropdown. " +
     "It is most useful for discovering player numbers so that you can write [[#]] to reference a player in mail.";
 
+  let playerSheet = function () {
+    let p = NeptunesPride.universe.galaxy.players;
+    let output = [];
+    let fields = [
+      "alias",
+      "total_stars",
+      "shipsPerTick",
+      "total_strength",
+      "total_economy",
+      "total_fleets",
+      "total_industry",
+      "total_science",
+    ];
+    output.push(fields.join(","));
+    for (let i in p) {
+      player = { ...p[i] };
+      const record = fields.map((f) => p[i][f]);
+      output.push(record.join(","));
+    }
+    clip(output.join("\n"));
+  };
+  hotkey("$", playerSheet);
+  playerSheet.help =
+    "Generate a player summary mean to be made into a spreadsheet." +
+    "<p>The clipboard should be pasted into a CSV and then imported.";
+
   let drawOverlayString = function (context, s, x, y, fgColor) {
     context.fillStyle = "#000000";
     for (let smear = 1; smear < 4; ++smear) {


### PR DESCRIPTION
I needed to have a spreadsheet where I could compare global values of one group of player's ships, industry, etc, with another group of players to assess different alliance's chances.

Map '$' to this functionality and stick the csv on the clipboard.

Sample output:

alias,total_stars,shipsPerTick,total_strength,total_economy,total_fleets,total_industry,total_science Long Beard,2,83.31,9130,86,1,43,10
Capn Paddy McBlowfish (KO),0,0,0,0,0,0,0
Toothless Pete,1,182.75,8897,44,4,86,20
CapN Grinch (AFK),0,0,0,0,0,0,0
El capitan (QUIT),0,0,0,0,0,0,0
Captain Scurvyshorts (KO),0,0,0,0,0,0,0
Momonga,145,6794.13,533653,3719,117,2938,835
TeFinete (QUIT),0,0,0,0,0,0,0
RowBoat (KO),0,0,0,0,0,0,0
Anne Bonney,64,3706,211464,2790,83,1744,234
One Eyed Brand,284,13855.75,542509,6571,385,5834,1017 Sponge Bob Square Pirate (QUIT),0,0,0,0,0,0,0
Star Fleet (KO),0,0,0,0,0,0,0
Captain Puffypants (QUIT),0,0,0,0,0,0,0
Rardie (KO),0,0,0,0,0,0,0
Auddog (QUIT),0,0,0,0,0,0,0