### PR TITLE
Extract image_url into its own file by way of example.

### DIFF
--- a/source/imageutils.js
+++ b/source/imageutils.js
@@ -1,0 +1,10 @@
+export const image_url = (str) => {
+  const protocol = "^(https://)";
+  const domains = "(i.ibb.co/|i.imgur.com/)";
+  const content = "([-#/;&_\\w]{1,150})";
+  const images =
+    "(.)(gif|jpe?g|tiff?|png|webp|bmp|GIF|JPE?G|TIFF?|PNG|WEBP|BMP)$";
+  let regex = new RegExp(protocol + domains + content + images);
+  let unused = "foo";
+  return regex.test(str);
+};

--- a/source/intel.js
+++ b/source/intel.js
@@ -1,19 +1,9 @@
+import { image_url } from "./imageutils";
 import { clip, lastClip } from "./hotkey";
 
 /* global define, Crux, NeptunesPride, Mousetrap, jQuery, Cookies, $ */
 
 const sat_version = "2.21";
-
-const image_url = (str) => {
-  const protocol = "^(https://)";
-  const domains = "(i.ibb.co/|i.imgur.com/)";
-  const content = "([-#/;&_\\w]{1,150})";
-  const images =
-    "(.)(gif|jpe?g|tiff?|png|webp|bmp|GIF|JPE?G|TIFF?|PNG|WEBP|BMP)$";
-  let regex = new RegExp(protocol + domains + content + images);
-  let unused = "foo";
-  return regex.test(str);
-};
 
 //Custom UI ComponentsNe
 const PlayerNameIconRowLink = (player) => {


### PR DESCRIPTION
Here is a minimal example of what you need to do to move parts of intel.js into a new file.

It's as straightforward as cutting and pasting the original into the new file and putting the keyword 'export' before each declaration you want access to outside that file. Then, in intel.js, you can import the symbol and use it as before.