### PR TITLE
Enable SAT to work in Firefox.

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -30,7 +30,7 @@
       }
     ],
     "background": {
-      "service_worker": "worker.js"
+      "scripts": ["worker.js"]
     },
   
     "icons": {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -30,7 +30,7 @@
       }
     ],
     "background": {
-      "service_worker": "worker.js"
+      "scripts": ["worker.js"]
     },
   
     "icons": {


### PR DESCRIPTION
SAT is not available for Firefox, however if we changed the `manifest.json` a bit, then the same code works for Firefox as well.

Testing on Firefox:
1. Go to `about:debugging` -> This Firefox -> Load Temporary Add-on and then choose the manifest.json and it should load SAT.
2. Go to `about:addons` -> Stoned Ape Tools -> Permissions and allow it to access data from https://np.ironhelmet.com.

Don't know why you have to manually give it permission or how to make it automatically ask for permission. If you don't manually give it permission, it throws an error `Error: Missing host permission for the tab`.

(This is my first pull request, so apologies for any mistakes.)